### PR TITLE
✨ : 웨더뷰 및 네비게이션 컨트롤러 추가

### DIFF
--- a/shaka/shaka/View/Base.lproj/Main.storyboard
+++ b/shaka/shaka/View/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="44H-t9-T3D">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
@@ -19,7 +19,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="XqD-ik-1FY">
-                                <rect key="frame" x="20" y="44" width="374" height="778"/>
+                                <rect key="frame" x="20" y="88" width="374" height="745"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hzn-f1-5PU" userLabel="NavView">
                                         <rect key="frame" x="0.0" y="0.0" width="374" height="46"/>
@@ -62,7 +62,7 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jqH-uo-K0J" userLabel="TitleView">
-                                        <rect key="frame" x="0.0" y="77.5" width="374" height="29"/>
+                                        <rect key="frame" x="0.0" y="71" width="374" height="29"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="GNI-yR-wlf">
                                                 <rect key="frame" x="0.0" y="0.0" width="166" height="29"/>
@@ -95,7 +95,7 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8ZF-gP-of2" userLabel="PersonalView">
-                                        <rect key="frame" x="0.0" y="138" width="374" height="134"/>
+                                        <rect key="frame" x="0.0" y="125" width="374" height="134"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QTU-M4-hQT">
                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="134"/>
@@ -186,7 +186,7 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hj9-JB-rcK" userLabel="SurfView">
-                                        <rect key="frame" x="0.0" y="304" width="374" height="190"/>
+                                        <rect key="frame" x="0.0" y="284" width="374" height="190"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="MainBackground" translatesAutoresizingMaskIntoConstraints="NO" id="g6g-ij-UAX">
                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="190"/>
@@ -199,7 +199,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="29" translatesAutoresizingMaskIntoConstraints="NO" id="g5E-u5-ldM">
                                                 <rect key="frame" x="20" y="20" width="334" height="150"/>
                                                 <subviews>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="tjz-ux-f1o">
+                                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tjz-ux-f1o">
                                                         <rect key="frame" x="0.0" y="0.0" width="118.5" height="43"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="가장 가까운 해변은" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HLC-qq-ZqD">
@@ -252,7 +252,7 @@
                                                     <constraint firstItem="tjz-ux-f1o" firstAttribute="leading" secondItem="g5E-u5-ldM" secondAttribute="leading" id="Xvd-fT-fMF"/>
                                                 </constraints>
                                             </stackView>
-                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="22f-QZ-2kZ">
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="22f-QZ-2kZ" userLabel="ButtonLink">
                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="190"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <state key="normal" title="Button"/>
@@ -268,7 +268,7 @@
                                             <constraint firstAttribute="bottom" secondItem="g5E-u5-ldM" secondAttribute="bottom" constant="20" id="JIl-YE-iCw"/>
                                             <constraint firstItem="g5E-u5-ldM" firstAttribute="leading" secondItem="hj9-JB-rcK" secondAttribute="leading" constant="20" id="K6o-Ol-LiM"/>
                                             <constraint firstAttribute="trailing" secondItem="g5E-u5-ldM" secondAttribute="trailing" constant="20" id="QwC-nt-k9m"/>
-                                            <constraint firstAttribute="height" constant="190" id="UjC-dR-dpj"/>
+                                            <constraint firstAttribute="height" constant="190" id="cac-ge-49l"/>
                                             <constraint firstItem="5MZ-9B-mla" firstAttribute="leading" secondItem="hj9-JB-rcK" secondAttribute="leading" id="crC-sb-y8t"/>
                                             <constraint firstItem="g6g-ij-UAX" firstAttribute="top" secondItem="hj9-JB-rcK" secondAttribute="top" id="fYr-Hz-2uw"/>
                                             <constraint firstAttribute="trailing" secondItem="g6g-ij-UAX" secondAttribute="trailing" id="jJf-OW-0H8"/>
@@ -279,7 +279,7 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xM9-2H-bXZ" userLabel="WebSheetView">
-                                        <rect key="frame" x="0.0" y="525.5" width="374" height="123"/>
+                                        <rect key="frame" x="0.0" y="499" width="374" height="123"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="oxa-U6-j8G">
                                                 <rect key="frame" x="11.5" y="0.0" width="351" height="123"/>
@@ -378,7 +378,7 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lmb-dw-pTc" userLabel="BottomView">
-                                        <rect key="frame" x="0.0" y="680" width="374" height="98"/>
+                                        <rect key="frame" x="0.0" y="647" width="374" height="98"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0XS-Zj-wgk">
                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="50"/>
@@ -440,11 +440,11 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="XqD-ik-1FY" secondAttribute="trailing" constant="20" id="HQp-Xp-QLd"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="XqD-ik-1FY" secondAttribute="bottom" constant="40" id="Yma-nK-JFd"/>
                             <constraint firstItem="XqD-ik-1FY" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="dTo-x8-cFI"/>
                             <constraint firstItem="XqD-ik-1FY" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="pov-ff-G3v"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" id="ts8-JY-MWS"/>
                     <connections>
                         <outlet property="cardBackground" destination="QTU-M4-hQT" id="hn1-70-mXD"/>
                         <outlet property="getWaterButton" destination="UhK-Hc-lWZ" id="zW5-mZ-l3W"/>
@@ -455,7 +455,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="18.840579710144929" y="95.758928571428569"/>
+            <point key="canvasLocation" x="928.98550724637687" y="95.758928571428569"/>
         </scene>
         <!--PushViewController-->
         <scene sceneID="NmD-dA-3SH">
@@ -465,7 +465,7 @@
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="I6c-JA-na4" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="664" y="-121"/>
+            <point key="canvasLocation" x="1573.913043478261" y="-121.20535714285714"/>
         </scene>
         <!--Timer-->
         <scene sceneID="L26-JG-dsp">
@@ -475,7 +475,28 @@
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iHh-Vs-fRX" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="707" y="106"/>
+            <point key="canvasLocation" x="1616.6666666666667" y="105.80357142857143"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="ifM-PD-0sN">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="44H-t9-T3D" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="u3A-xf-iXj">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="gLa-uj-R6P">
+                        <autoresizingMask key="autoresizingMask"/>
+                    </toolbar>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="dTs-CV-Kai"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="WsV-Pe-D8O" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="18.840579710144929" y="95.758928571428569"/>
         </scene>
     </scenes>
     <resources>

--- a/shaka/shaka/View/WeatherNotification.storyboard
+++ b/shaka/shaka/View/WeatherNotification.storyboard
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="5fF-la-Shw">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Push View Controller-->
+        <!--실시간 해변 알림-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
                 <viewController storyboardIdentifier="PushViewController" id="Y6W-OH-hqX" customClass="PushViewController" customModule="shaka" customModuleProvider="target" sceneMemberID="viewController">
@@ -16,135 +17,191 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="3Lj-EF-0EQ">
-                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="WeatherCell" rowHeight="85" id="gHs-Fy-BJq" userLabel="WeatherCell" customClass="WeatherTVC" customModule="shaka" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.5" width="414" height="85"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="gHs-Fy-BJq" id="R9g-gj-fob">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="85"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jzs-XX-kb4">
-                                                    <rect key="frame" x="20" y="11" width="374" height="63"/>
-                                                    <subviews>
-                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ThunderIcon" translatesAutoresizingMaskIntoConstraints="NO" id="6O8-5V-tbB">
-                                                            <rect key="frame" x="0.0" y="0.5" width="62" height="62"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" constant="62" id="qRI-cb-muv"/>
-                                                                <constraint firstAttribute="width" constant="62" id="xGo-NH-FTf"/>
-                                                            </constraints>
-                                                        </imageView>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="03u-SL-SDn">
-                                                            <rect key="frame" x="77" y="0.0" width="297" height="63"/>
-                                                            <subviews>
-                                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="WpF-t4-yWn">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="65" height="21"/>
-                                                                    <subviews>
-                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="감전 위험!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pSw-X7-RML">
-                                                                            <rect key="frame" x="0.0" y="0.0" width="65" height="21"/>
-                                                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                                            <nil key="textColor"/>
-                                                                            <nil key="highlightedColor"/>
-                                                                        </label>
-                                                                    </subviews>
-                                                                </stackView>
-                                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="a5E-CT-Cli">
-                                                                    <rect key="frame" x="0.0" y="21" width="183.5" height="21"/>
-                                                                    <subviews>
-                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="월포 해변에 번개 주의보가 내렸습니다." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NnS-ng-XJ3">
-                                                                            <rect key="frame" x="0.0" y="0.0" width="183.5" height="21"/>
-                                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                                            <nil key="textColor"/>
-                                                                            <nil key="highlightedColor"/>
-                                                                        </label>
-                                                                    </subviews>
-                                                                </stackView>
-                                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="U1U-IC-jf6">
-                                                                    <rect key="frame" x="0.0" y="42" width="32" height="21"/>
-                                                                    <subviews>
-                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="14:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a87-Ex-8Oq">
-                                                                            <rect key="frame" x="0.0" y="0.0" width="32" height="21"/>
-                                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                                            <nil key="textColor"/>
-                                                                            <nil key="highlightedColor"/>
-                                                                        </label>
-                                                                    </subviews>
-                                                                </stackView>
-                                                            </subviews>
-                                                        </stackView>
-                                                    </subviews>
-                                                    <color key="backgroundColor" systemColor="systemGray4Color"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="bottom" secondItem="03u-SL-SDn" secondAttribute="bottom" id="J79-ti-Hvb"/>
-                                                        <constraint firstItem="6O8-5V-tbB" firstAttribute="leading" secondItem="Jzs-XX-kb4" secondAttribute="leading" id="QSl-QQ-xMc"/>
-                                                        <constraint firstItem="6O8-5V-tbB" firstAttribute="centerY" secondItem="Jzs-XX-kb4" secondAttribute="centerY" id="XD8-VA-gW1"/>
-                                                        <constraint firstAttribute="trailing" secondItem="03u-SL-SDn" secondAttribute="trailing" id="bw2-jz-Pmf"/>
-                                                        <constraint firstItem="03u-SL-SDn" firstAttribute="top" secondItem="Jzs-XX-kb4" secondAttribute="top" id="qKX-z3-S4F"/>
-                                                        <constraint firstItem="03u-SL-SDn" firstAttribute="leading" secondItem="6O8-5V-tbB" secondAttribute="trailing" constant="15" id="tmg-SO-HXW"/>
-                                                    </constraints>
-                                                </view>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="trailingMargin" secondItem="Jzs-XX-kb4" secondAttribute="trailing" id="30a-j2-ods"/>
-                                                <constraint firstItem="Jzs-XX-kb4" firstAttribute="top" secondItem="R9g-gj-fob" secondAttribute="topMargin" id="Qzt-Rw-nPO"/>
-                                                <constraint firstItem="Jzs-XX-kb4" firstAttribute="leading" secondItem="R9g-gj-fob" secondAttribute="leadingMargin" id="Xp5-R8-DRZ"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="Jzs-XX-kb4" secondAttribute="bottom" id="YsR-lo-yQU"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                        <connections>
-                                            <outlet property="weatherImageView" destination="6O8-5V-tbB" id="YPN-Nb-aA6"/>
-                                            <outlet property="weatherInfoView" destination="NnS-ng-XJ3" id="puE-Lf-w4Z"/>
-                                            <outlet property="weatherTimeView" destination="a87-Ex-8Oq" id="lMU-y9-r0V"/>
-                                            <outlet property="weatherTitleView" destination="pSw-X7-RML" id="XdM-Pc-HQf"/>
-                                        </connections>
-                                    </tableViewCell>
-                                </prototypes>
-                            </tableView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="7uy-ne-dNl">
+                                <rect key="frame" x="0.0" y="44" width="414" height="300"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ljk-bA-4nI">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="100"/>
+                                        <subviews>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ThunderIcon" translatesAutoresizingMaskIntoConstraints="NO" id="z1h-fl-7SA">
+                                                <rect key="frame" x="30" y="18.5" width="62" height="63"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="62" id="fHX-Qf-2S8"/>
+                                                    <constraint firstAttribute="height" constant="63" id="kZo-M6-AHB"/>
+                                                </constraints>
+                                            </imageView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="g6b-3X-Fuc">
+                                                <rect key="frame" x="100" y="20" width="183" height="60.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="감전 위험!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="V3H-r5-dEt">
+                                                        <rect key="frame" x="0.0" y="0.0" width="65" height="19.5"/>
+                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                                                        <color key="textColor" name="AccentColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="월포 해변에 번개 주의보가 내렸습니다." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B2z-sv-sxa">
+                                                        <rect key="frame" x="0.0" y="25.5" width="183" height="14.5"/>
+                                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="14:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="asG-jz-HhF">
+                                                        <rect key="frame" x="0.0" y="46" width="34" height="14.5"/>
+                                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
+                                                        <color key="textColor" name="SubFontColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ptB-Wb-glh">
+                                                <rect key="frame" x="20" y="98" width="374" height="2"/>
+                                                <color key="backgroundColor" name="CardBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="2" id="IkP-7Z-ie8"/>
+                                                </constraints>
+                                            </view>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="100" id="0Yg-GQ-IoU"/>
+                                            <constraint firstAttribute="bottom" secondItem="ptB-Wb-glh" secondAttribute="bottom" id="9db-6m-hov"/>
+                                            <constraint firstAttribute="trailing" secondItem="ptB-Wb-glh" secondAttribute="trailing" constant="20" id="CcN-rb-K0k"/>
+                                            <constraint firstItem="ptB-Wb-glh" firstAttribute="leading" secondItem="Ljk-bA-4nI" secondAttribute="leading" constant="20" id="Odv-tK-Njb"/>
+                                            <constraint firstItem="g6b-3X-Fuc" firstAttribute="leading" secondItem="z1h-fl-7SA" secondAttribute="trailing" constant="8" symbolic="YES" id="VEv-Un-Lua"/>
+                                            <constraint firstItem="z1h-fl-7SA" firstAttribute="leading" secondItem="Ljk-bA-4nI" secondAttribute="leading" constant="30" id="YJV-mQ-gCI"/>
+                                            <constraint firstItem="z1h-fl-7SA" firstAttribute="centerY" secondItem="g6b-3X-Fuc" secondAttribute="centerY" id="pgg-JW-ZGk"/>
+                                            <constraint firstItem="z1h-fl-7SA" firstAttribute="centerY" secondItem="Ljk-bA-4nI" secondAttribute="centerY" id="tKV-gm-q27"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FED-N2-Cmt">
+                                        <rect key="frame" x="0.0" y="100" width="414" height="100"/>
+                                        <subviews>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="WaveIcon" translatesAutoresizingMaskIntoConstraints="NO" id="ZnL-2p-wUf">
+                                                <rect key="frame" x="30" y="18.5" width="62" height="63"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="63" id="hO8-6V-bZv"/>
+                                                    <constraint firstAttribute="width" constant="62" id="nDh-R2-PD7"/>
+                                                </constraints>
+                                            </imageView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="fRl-9i-55K">
+                                                <rect key="frame" x="100" y="20" width="183" height="60.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="파도가 높아요!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PlS-UT-VVu">
+                                                        <rect key="frame" x="0.0" y="0.0" width="92.5" height="19.5"/>
+                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                                                        <color key="textColor" name="MainColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="월포 해변에 풍랑 주의보가 내렸습니다." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kew-en-gBW">
+                                                        <rect key="frame" x="0.0" y="25.5" width="183" height="14.5"/>
+                                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="13:30" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4DF-sk-y0D">
+                                                        <rect key="frame" x="0.0" y="46" width="33.5" height="14.5"/>
+                                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
+                                                        <color key="textColor" name="SubFontColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xie-pH-f7u">
+                                                <rect key="frame" x="20" y="98" width="374" height="2"/>
+                                                <color key="backgroundColor" name="CardBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="2" id="6vG-BK-ErE"/>
+                                                </constraints>
+                                            </view>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="fRl-9i-55K" firstAttribute="leading" secondItem="ZnL-2p-wUf" secondAttribute="trailing" constant="8" symbolic="YES" id="KnJ-2O-zip"/>
+                                            <constraint firstAttribute="bottom" secondItem="Xie-pH-f7u" secondAttribute="bottom" id="Kre-LV-doO"/>
+                                            <constraint firstAttribute="height" constant="100" id="PwN-13-F2w"/>
+                                            <constraint firstItem="Xie-pH-f7u" firstAttribute="leading" secondItem="FED-N2-Cmt" secondAttribute="leading" constant="20" id="S2I-VE-9vB"/>
+                                            <constraint firstItem="ZnL-2p-wUf" firstAttribute="leading" secondItem="FED-N2-Cmt" secondAttribute="leading" constant="30" id="iCc-yb-mdQ"/>
+                                            <constraint firstItem="ZnL-2p-wUf" firstAttribute="centerY" secondItem="FED-N2-Cmt" secondAttribute="centerY" id="jqU-H4-8KT"/>
+                                            <constraint firstAttribute="trailing" secondItem="Xie-pH-f7u" secondAttribute="trailing" constant="20" id="mfQ-Gv-lC3"/>
+                                            <constraint firstItem="ZnL-2p-wUf" firstAttribute="centerY" secondItem="fRl-9i-55K" secondAttribute="centerY" id="vMY-3U-6sQ"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Dc3-6z-itY">
+                                        <rect key="frame" x="0.0" y="200" width="414" height="100"/>
+                                        <subviews>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="WindIcon" translatesAutoresizingMaskIntoConstraints="NO" id="h9I-iL-gus">
+                                                <rect key="frame" x="30" y="18.5" width="62" height="63"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="63" id="SQr-Y7-Vbr"/>
+                                                    <constraint firstAttribute="width" constant="62" id="ZcF-ES-Dy0"/>
+                                                </constraints>
+                                            </imageView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="7bl-AX-pt1">
+                                                <rect key="frame" x="100" y="20" width="172.5" height="60.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="태풍이 오고 있어요!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dcf-zm-wRd">
+                                                        <rect key="frame" x="0.0" y="0.0" width="124" height="19.5"/>
+                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                                                        <color key="textColor" red="0.53333333333333333" green="0.76078431372549016" blue="0.92549019607843142" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="월포 해변에 태풍 경보가 내렸습니다." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ozh-Xo-fAK">
+                                                        <rect key="frame" x="0.0" y="25.5" width="172.5" height="14.5"/>
+                                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="13:01" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sjz-yU-475">
+                                                        <rect key="frame" x="0.0" y="46" width="32" height="14.5"/>
+                                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
+                                                        <color key="textColor" name="SubFontColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="h9I-iL-gus" firstAttribute="centerY" secondItem="7bl-AX-pt1" secondAttribute="centerY" id="CYd-DN-NtM"/>
+                                            <constraint firstItem="h9I-iL-gus" firstAttribute="leading" secondItem="Dc3-6z-itY" secondAttribute="leading" constant="30" id="Cpc-vq-W8p"/>
+                                            <constraint firstAttribute="height" constant="100" id="XL4-gc-uAK"/>
+                                            <constraint firstItem="h9I-iL-gus" firstAttribute="centerY" secondItem="Dc3-6z-itY" secondAttribute="centerY" id="boi-3N-BUW"/>
+                                            <constraint firstItem="7bl-AX-pt1" firstAttribute="leading" secondItem="h9I-iL-gus" secondAttribute="trailing" constant="8" symbolic="YES" id="fMU-Pv-yCc"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="3Lj-EF-0EQ" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="9M0-31-mYz"/>
-                            <constraint firstItem="3Lj-EF-0EQ" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="cCw-hH-Xet"/>
-                            <constraint firstItem="3Lj-EF-0EQ" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="rBM-Vk-B5J"/>
-                            <constraint firstItem="3Lj-EF-0EQ" firstAttribute="bottom" secondItem="vDu-zF-Fre" secondAttribute="bottom" id="wWk-5r-YOt"/>
+                            <constraint firstItem="7uy-ne-dNl" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="9Uv-uV-2un"/>
+                            <constraint firstItem="7uy-ne-dNl" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="iNN-KF-saG"/>
+                            <constraint firstItem="7uy-ne-dNl" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="r0z-ah-JAe"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="I5x-HX-W33"/>
+                    <navigationItem key="navigationItem" title="실시간 해변 알림" largeTitleDisplayMode="always" id="I5x-HX-W33"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="940.57971014492762" y="137.94642857142856"/>
         </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="Byd-hq-zVm">
-            <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="5fF-la-Shw" sceneMemberID="viewController">
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="jJ8-AK-6fS">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <nil name="viewControllers"/>
-                    <connections>
-                        <segue destination="Y6W-OH-hqX" kind="relationship" relationship="rootViewController" id="F7N-vU-Scg"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="E33-LJ-mfZ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="137.68115942028987" y="137.94642857142856"/>
-        </scene>
     </scenes>
     <resources>
         <image name="ThunderIcon" width="150.5" height="149.5"/>
+        <image name="WaveIcon" width="150.5" height="149.5"/>
+        <image name="WindIcon" width="150.5" height="149.5"/>
+        <namedColor name="AccentColor">
+            <color red="1" green="0.79199999570846558" blue="0.15700000524520874" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="CardBackgroundColor">
+            <color red="0.93699997663497925" green="0.94499999284744263" blue="0.97299998998641968" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="MainColor">
+            <color red="0.18000000715255737" green="0.3449999988079071" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="SubFontColor">
+            <color red="0.67100000381469727" green="0.68999999761581421" blue="0.7369999885559082" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemGray4Color">
-            <color red="0.81960784313725488" green="0.81960784313725488" blue="0.83921568627450982" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
## 세부 사항
<img src="https://user-images.githubusercontent.com/77766769/182018076-0a515072-fd77-4df5-b908-3400c91ee563.png" width="300">

- 메인 스토리보드에 네비게이션 컨트롤러 추가

<img src="https://user-images.githubusercontent.com/77766769/182018090-e284adbf-f160-4355-a5c4-9f7f296e723a.png" width="300">

- 웨더뷰 스토리보드 추가 및 구성

## 특이사항
- 메인 스토리보드에 네비게이션 컨트롤러 추가시 상단에 네비게이션 아이템 영역이 나타나 전체 뷰가 하단으로 밀리는 현상
  - 네비게이션바 커스텀 or 기존 버튼으로 덮는 방법 중 고민입니다.

## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)

- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
